### PR TITLE
Polish home view layout handling for styled landing experience

### DIFF
--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Account/Login.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Account/Login.cshtml
@@ -3,46 +3,43 @@
     ViewData["Title"] = "Login";
 }
 
-<div class="row justify-content-center">
-    <div class="col-md-5">
-        <div class="card">
-            <div class="card-header">
-                <h3 class="card-title text-center">Sign In</h3>
-                <p class="text-center text-muted">Welcome back to the Citizen Engagement Portal</p>
-            </div>
-            <div class="card-body">
-                <form asp-action="Login" method="post">
-                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Email" class="form-label"></label>
-                        <input asp-for="Email" class="form-control" />
-                        <span asp-validation-for="Email" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Password" class="form-label"></label>
-                        <input asp-for="Password" class="form-control" />
-                        <span asp-validation-for="Password" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3 form-check">
-                        <input asp-for="RememberMe" class="form-check-input" />
-                        <label asp-for="RememberMe" class="form-check-label"></label>
-                    </div>
-                    
-                    <div class="d-grid">
-                        <button type="submit" class="btn btn-primary">Sign In</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card-footer text-center">
-                <p>Don't have an account? <a asp-action="Register">Register here</a></p>
-                <p class="mb-0">
-                    <small>Demo credentials:</small><br>
-                    <small>Admin: admin@cep.local / Admin123!</small><br>
-                    <small>Citizen: citizen@example.com / Citizen123!</small>
-                </p>
+<div class="auth-wrapper">
+    <div class="auth-card card shadow-none">
+        <div class="card-header text-center">
+            <span class="badge-soft text-uppercase">Welcome back</span>
+            <h2 class="h3 text-white mt-3 mb-2">Sign in to the portal</h2>
+            <p class="text-white-50 mb-0">Access dashboards, monitor updates, and stay in sync with your community.</p>
+        </div>
+        <div class="card-body">
+            <form asp-action="Login" method="post" class="d-flex flex-column gap-3">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+                <div>
+                    <label asp-for="Email" class="form-label fw-semibold">Email</label>
+                    <input asp-for="Email" class="form-control" />
+                    <span asp-validation-for="Email" class="text-danger"></span>
+                </div>
+
+                <div>
+                    <label asp-for="Password" class="form-label fw-semibold">Password</label>
+                    <input asp-for="Password" class="form-control" />
+                    <span asp-validation-for="Password" class="text-danger"></span>
+                </div>
+
+                <div class="form-check">
+                    <input asp-for="RememberMe" class="form-check-input" />
+                    <label asp-for="RememberMe" class="form-check-label"></label>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-lg">Sign in</button>
+            </form>
+        </div>
+        <div class="card-footer text-center">
+            <p class="mb-2">Don&apos;t have an account? <a asp-action="Register">Register here</a></p>
+            <div class="text-white-50 small">
+                <div class="mb-1">Demo credentials</div>
+                <div>Admin: admin@cep.local / Admin123!</div>
+                <div>Citizen: citizen@example.com / Citizen123!</div>
             </div>
         </div>
     </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Account/Register.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Account/Register.cshtml
@@ -3,61 +3,60 @@
     ViewData["Title"] = "Register";
 }
 
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h3 class="card-title text-center">Create Account</h3>
-                <p class="text-center text-muted">Join the Citizen Engagement Portal</p>
-            </div>
-            <div class="card-body">
-                <form asp-action="Register" method="post">
+<div class="auth-wrapper">
+    <div class="auth-card card shadow-none">
+        <div class="card-header text-center">
+            <span class="badge-soft text-uppercase">Join the portal</span>
+            <h2 class="h3 text-white mt-3 mb-2">Create your civic account</h2>
+            <p class="text-white-50 mb-0">Collaborate with neighbors and officials, report issues, and receive transparent updates in real time.</p>
+        </div>
+        <div class="card-body">
+            <form asp-action="Register" method="post" class="row g-3">
+                <div class="col-12">
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Name" class="form-label"></label>
-                        <input asp-for="Name" class="form-control" />
-                        <span asp-validation-for="Name" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Email" class="form-label"></label>
-                        <input asp-for="Email" class="form-control" />
-                        <span asp-validation-for="Email" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Phone" class="form-label"></label>
-                        <input asp-for="Phone" class="form-control" />
-                        <span asp-validation-for="Phone" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Address" class="form-label"></label>
-                        <textarea asp-for="Address" class="form-control" rows="3"></textarea>
-                        <span asp-validation-for="Address" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Password" class="form-label"></label>
-                        <input asp-for="Password" class="form-control" />
-                        <span asp-validation-for="Password" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="ConfirmPassword" class="form-label"></label>
-                        <input asp-for="ConfirmPassword" class="form-control" />
-                        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="d-grid">
-                        <button type="submit" class="btn btn-primary">Register</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card-footer text-center">
-                <p>Already have an account? <a asp-action="Login">Sign in</a></p>
-            </div>
+                </div>
+
+                <div class="col-12">
+                    <label asp-for="Name" class="form-label fw-semibold">Full name</label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="col-12">
+                    <label asp-for="Email" class="form-label fw-semibold">Email</label>
+                    <input asp-for="Email" class="form-control" />
+                    <span asp-validation-for="Email" class="text-danger"></span>
+                </div>
+
+                <div class="col-md-6">
+                    <label asp-for="Phone" class="form-label fw-semibold">Phone</label>
+                    <input asp-for="Phone" class="form-control" />
+                    <span asp-validation-for="Phone" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="Address" class="form-label fw-semibold">Address</label>
+                    <textarea asp-for="Address" class="form-control" rows="3"></textarea>
+                    <span asp-validation-for="Address" class="text-danger"></span>
+                </div>
+
+                <div class="col-md-6">
+                    <label asp-for="Password" class="form-label fw-semibold">Password</label>
+                    <input asp-for="Password" class="form-control" />
+                    <span asp-validation-for="Password" class="text-danger"></span>
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="ConfirmPassword" class="form-label fw-semibold">Confirm password</label>
+                    <input asp-for="ConfirmPassword" class="form-control" />
+                    <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+                </div>
+
+                <div class="col-12 d-grid">
+                    <button type="submit" class="btn btn-primary btn-lg">Create account</button>
+                </div>
+            </form>
+        </div>
+        <div class="card-footer text-center">
+            <p class="mb-0">Already have an account? <a asp-action="Login">Sign in</a></p>
         </div>
     </div>
 </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Admin/Analytics.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Admin/Analytics.cshtml
@@ -3,130 +3,138 @@
     ViewData["Title"] = "Analytics Dashboard";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2>Analytics Dashboard</h2>
-    <a asp-controller="Admin" asp-action="Index" class="btn btn-outline-secondary">
-        <i class="fas fa-arrow-left me-2"></i>Back to Dashboard
-    </a>
-</div>
-
-<div class="row mb-4">
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h3 class="text-primary">@Model.ResolutionTime.Average.ToString("F1")</h3>
-                <h6 class="card-title">Avg. Resolution Time (days)</h6>
-            </div>
-        </div>
+<div class="page-header">
+    <div>
+        <h1 class="page-title">Analytics dashboard</h1>
+        <p class="page-subtitle">Visualize trends, resolution velocity, and engagement patterns to keep your city service machine humming.</p>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h3 class="text-success">@Model.ResolutionTime.Fastest.ToString("F1")</h3>
-                <h6 class="card-title">Fastest Resolution (days)</h6>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h3 class="text-danger">@Model.ResolutionTime.Slowest.ToString("F1")</h3>
-                <h6 class="card-title">Slowest Resolution (days)</h6>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-center">
-            <div class="card-body">
-                <h3 class="text-info">@Model.IssuesByCategory.Count</h3>
-                <h6 class="card-title">Total Categories</h6>
-            </div>
-        </div>
+    <div class="page-actions">
+        <a asp-controller="Admin" asp-action="Index" class="btn btn-soft-light">
+            <i class="fas fa-arrow-left me-2"></i>Back to dashboard
+        </a>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Issues by Category</h5>
+<div class="metric-grid">
+    <div class="metric-tile gradient-blue">
+        <div class="label">Avg resolution (days)</div>
+        <div class="value">@Model.ResolutionTime.Average.ToString("F1")</div>
+        <div class="icon"><i class="fas fa-bolt"></i></div>
+    </div>
+    <div class="metric-tile gradient-emerald">
+        <div class="label">Fastest resolution</div>
+        <div class="value">@Model.ResolutionTime.Fastest.ToString("F1")</div>
+        <div class="icon"><i class="fas fa-gauge-high"></i></div>
+    </div>
+    <div class="metric-tile gradient-amber">
+        <div class="label">Slowest resolution</div>
+        <div class="value">@Model.ResolutionTime.Slowest.ToString("F1")</div>
+        <div class="icon"><i class="fas fa-hourglass-half"></i></div>
+    </div>
+    <div class="metric-tile gradient-cyan">
+        <div class="label">Active categories</div>
+        <div class="value">@Model.IssuesByCategory.Count</div>
+        <div class="icon"><i class="fas fa-sitemap"></i></div>
+    </div>
+</div>
+
+<div class="row g-4">
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Issues by category</div>
+                    <div class="subtitle">Where residents are focusing attention</div>
+                </div>
             </div>
-            <div class="card-body">
-                @if (Model.IssuesByCategory.Any())
-                {
-                    <canvas id="categoryChart" width="400" height="300"></canvas>
-                }
-                else
-                {
-                    <p class="text-muted text-center">No data available</p>
-                }
-            </div>
+            @if (Model.IssuesByCategory.Any())
+            {
+                <canvas id="categoryChart" width="400" height="300"></canvas>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No data available</p>
+                </div>
+            }
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Issues by Status</h5>
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Issues by status</div>
+                    <div class="subtitle">Pipeline distribution at a glance</div>
+                </div>
             </div>
-            <div class="card-body">
-                @if (Model.IssuesByStatus.Any())
-                {
-                    <canvas id="statusChart" width="400" height="300"></canvas>
-                }
-                else
-                {
-                    <p class="text-muted text-center">No data available</p>
-                }
-            </div>
+            @if (Model.IssuesByStatus.Any())
+            {
+                <canvas id="statusChart" width="400" height="300"></canvas>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No data available</p>
+                </div>
+            }
         </div>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Monthly Issue Trends</h5>
+<div class="row g-4 mt-1">
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Monthly trends</div>
+                    <div class="subtitle">How reporting volume is evolving</div>
+                </div>
             </div>
-            <div class="card-body">
-                @if (Model.IssuesByMonth.Any())
-                {
-                    <canvas id="monthlyChart" width="400" height="300"></canvas>
-                }
-                else
-                {
-                    <p class="text-muted text-center">No data available</p>
-                }
-            </div>
+            @if (Model.IssuesByMonth.Any())
+            {
+                <canvas id="monthlyChart" width="400" height="300"></canvas>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No data available</p>
+                </div>
+            }
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Top Problem Categories</h5>
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Top problem categories</div>
+                    <div class="subtitle">Where teams should focus next</div>
+                </div>
             </div>
-            <div class="card-body">
-                @if (Model.TopCategories.Any())
-                {
+            @if (Model.TopCategories.Any())
+            {
+                <div class="list-modern">
                     @foreach (var category in Model.TopCategories)
                     {
-                        <div class="d-flex justify-content-between align-items-center mb-3">
-                            <div class="d-flex align-items-center">
-                                <div class="rounded-circle me-3" style="width: 20px; height: 20px; background-color: @Model.IssuesByCategory.FirstOrDefault(c => c.Name == category.Name)?.Color ?? "#6B7280";"></div>
-                                <span>@category.Name</span>
+                        @{ var color = Model.IssuesByCategory.FirstOrDefault(c => c.Name == category.Name)?.Color ?? "#6B7280"; }
+                        <div class="list-modern-item d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="rounded-circle" style="width: 16px; height: 16px; background-color: @color;"></div>
+                                <span class="text-white">@category.Name</span>
                             </div>
-                            <div>
-                                <span class="badge bg-secondary me-2">@category.Count</span>
-                                <small class="text-muted">(@category.Percentage.ToString("F1")%)</small>
+                            <div class="text-end">
+                                <span class="badge-soft">@category.Count</span>
+                                <div class="text-white-50 small">@category.Percentage.ToString("F1")%</div>
                             </div>
                         </div>
                     }
-                }
-                else
-                {
-                    <p class="text-muted text-center">No data available</p>
-                }
-            </div>
+                </div>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No data available</p>
+                </div>
+            }
         </div>
     </div>
 </div>
@@ -134,75 +142,116 @@
 @section Scripts {
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        // Issues by Category Chart
-        const categoryCtx = document.getElementById('categoryChart').getContext('2d');
-        new Chart(categoryCtx, {
-            type: 'bar',
-            data: {
-                labels: [@Html.Raw(string.Join(",", Model.IssuesByCategory.Select(c => $"'{c.Name}'")))],
-                datasets: [{
-                    label: 'Number of Issues',
-                    data: [@string.Join(",", Model.IssuesByCategory.Select(c => c.Count))],
-                    backgroundColor: [@Html.Raw(string.Join(",", Model.IssuesByCategory.Select(c => $"'{c.Color}'")))],
-                    borderColor: [@Html.Raw(string.Join(",", Model.IssuesByCategory.Select(c => $"'{c.Color}'")))],
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                responsive: true,
-                scales: {
-                    y: {
-                        beginAtZero: true
-                    }
-                }
-            }
-        });
+        const categoryData = {
+            labels: [@Html.Raw(string.Join(",", Model.IssuesByCategory.Select(c => $"'{c.Name}'")))],
+            values: [@string.Join(",", Model.IssuesByCategory.Select(c => c.Count))],
+            colors: [@Html.Raw(string.Join(",", Model.IssuesByCategory.Select(c => $"'{c.Color}'")))]
+        };
 
-        // Issues by Status Chart
-        const statusCtx = document.getElementById('statusChart').getContext('2d');
-        new Chart(statusCtx, {
-            type: 'pie',
-            data: {
-                labels: [@Html.Raw(string.Join(",", Model.IssuesByStatus.Select(s => $"'{s.Name}'")))],
-                datasets: [{
-                    data: [@string.Join(",", Model.IssuesByStatus.Select(s => s.Count))],
-                    backgroundColor: [@Html.Raw(string.Join(",", Model.IssuesByStatus.Select(s => $"'{s.Color}'")))],
-                    borderColor: [@Html.Raw(string.Join(",", Model.IssuesByStatus.Select(s => $"'{s.Color}'")))],
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                responsive: true,
-                plugins: {
-                    legend: {
-                        position: 'bottom'
-                    }
-                }
-            }
-        });
+        const statusData = {
+            labels: [@Html.Raw(string.Join(",", Model.IssuesByStatus.Select(s => $"'{s.Name}'")))],
+            values: [@string.Join(",", Model.IssuesByStatus.Select(s => s.Count))],
+            colors: [@Html.Raw(string.Join(",", Model.IssuesByStatus.Select(s => $"'{s.Color}'")))]
+        };
 
-        // Monthly Trends Chart
-        const monthlyCtx = document.getElementById('monthlyChart').getContext('2d');
-        new Chart(monthlyCtx, {
-            type: 'line',
-            data: {
-                labels: [@Html.Raw(string.Join(",", Model.IssuesByMonth.Select(m => $"'{m.Month}'")))],
-                datasets: [{
-                    label: 'Issues Reported',
-                    data: [@string.Join(",", Model.IssuesByMonth.Select(m => m.Count))],
-                    borderColor: 'rgb(75, 192, 192)',
-                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                    tension: 0.1
-                }]
-            },
-            options: {
-                responsive: true,
-                scales: {
-                    y: {
-                        beginAtZero: true
+        const monthlyData = {
+            labels: [@Html.Raw(string.Join(",", Model.IssuesByMonth.Select(m => $"'{m.Month}'")))],
+            values: [@string.Join(",", Model.IssuesByMonth.Select(m => m.Count))]
+        };
+
+        if (categoryData.labels.length) {
+            const ctx = document.getElementById('categoryChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: categoryData.labels,
+                    datasets: [{
+                        label: 'Number of issues',
+                        data: categoryData.values,
+                        backgroundColor: categoryData.colors,
+                        borderColor: categoryData.colors,
+                        borderRadius: 12,
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: { color: '#cbd5f5' },
+                            grid: { color: 'rgba(148, 163, 184, 0.2)' }
+                        },
+                        x: {
+                            ticks: { color: '#cbd5f5' },
+                            grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                        }
+                    },
+                    plugins: {
+                        legend: { display: false }
                     }
                 }
-            }
-        });
+            });
+        }
+
+        if (statusData.labels.length) {
+            const ctx = document.getElementById('statusChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'doughnut',
+                data: {
+                    labels: statusData.labels,
+                    datasets: [{
+                        data: statusData.values,
+                        backgroundColor: statusData.colors,
+                        borderColor: 'rgba(15, 23, 42, 0.85)',
+                        borderWidth: 2
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    cutout: '65%',
+                    plugins: {
+                        legend: { position: 'bottom', labels: { color: '#cbd5f5' } }
+                    }
+                }
+            });
+        }
+
+        if (monthlyData.labels.length) {
+            const ctx = document.getElementById('monthlyChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: monthlyData.labels,
+                    datasets: [{
+                        label: 'Issues reported',
+                        data: monthlyData.values,
+                        borderColor: 'rgba(99, 102, 241, 1)',
+                        backgroundColor: 'rgba(99, 102, 241, 0.25)',
+                        tension: 0.35,
+                        fill: true,
+                        pointRadius: 4,
+                        pointBackgroundColor: '#fff'
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: { color: '#cbd5f5' },
+                            grid: { color: 'rgba(148, 163, 184, 0.2)' }
+                        },
+                        x: {
+                            ticks: { color: '#cbd5f5' },
+                            grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                        }
+                    },
+                    plugins: {
+                        legend: { display: false }
+                    }
+                }
+            });
+        }
     </script>
 }

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Admin/Index.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Admin/Index.cshtml
@@ -3,191 +3,182 @@
     ViewData["Title"] = "Admin Dashboard";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2>Admin Dashboard</h2>
+<div class="page-header">
     <div>
-        <span class="badge bg-danger me-2">Administrator</span>
-        <a asp-controller="Admin" asp-action="Analytics" class="btn btn-outline-primary">
+        <h1 class="page-title">Admin dashboard</h1>
+        <p class="page-subtitle">Monitor the health of the platform, oversee citywide collaboration, and take quick action on what matters most.</p>
+    </div>
+    <div class="page-actions">
+        <span class="badge-soft status-rejected text-uppercase">Administrator</span>
+        <a asp-controller="Admin" asp-action="Analytics" class="btn btn-primary btn-lg px-4">
             <i class="fas fa-chart-bar me-2"></i>Analytics
         </a>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-md-2">
-        <div class="card text-white bg-primary">
-            <div class="card-body text-center">
-                <h3>@Model.TotalIssues</h3>
-                <h6 class="card-title">Total Issues</h6>
-            </div>
-        </div>
+<div class="metric-grid">
+    <div class="metric-tile gradient-blue">
+        <div class="label">Total issues</div>
+        <div class="value">@Model.TotalIssues</div>
+        <div class="icon"><i class="fas fa-layer-group"></i></div>
     </div>
-    <div class="col-md-2">
-        <div class="card text-white bg-warning">
-            <div class="card-body text-center">
-                <h3>@Model.PendingIssues</h3>
-                <h6 class="card-title">Pending</h6>
-            </div>
-        </div>
+    <div class="metric-tile gradient-amber">
+        <div class="label">Pending</div>
+        <div class="value">@Model.PendingIssues</div>
+        <div class="icon"><i class="fas fa-clock"></i></div>
     </div>
-    <div class="col-md-2">
-        <div class="card text-white bg-info">
-            <div class="card-body text-center">
-                <h3>@Model.InProgressIssues</h3>
-                <h6 class="card-title">In Progress</h6>
-            </div>
-        </div>
+    <div class="metric-tile gradient-cyan">
+        <div class="label">In progress</div>
+        <div class="value">@Model.InProgressIssues</div>
+        <div class="icon"><i class="fas fa-spinner"></i></div>
     </div>
-    <div class="col-md-2">
-        <div class="card text-white bg-success">
-            <div class="card-body text-center">
-                <h3>@Model.ResolvedIssues</h3>
-                <h6 class="card-title">Resolved</h6>
-            </div>
-        </div>
+    <div class="metric-tile gradient-emerald">
+        <div class="label">Resolved</div>
+        <div class="value">@Model.ResolvedIssues</div>
+        <div class="icon"><i class="fas fa-check"></i></div>
     </div>
-    <div class="col-md-2">
-        <div class="card text-white bg-secondary">
-            <div class="card-body text-center">
-                <h3>@Model.TotalUsers</h3>
-                <h6 class="card-title">Total Users</h6>
-            </div>
-        </div>
+    <div class="metric-tile gradient-slate">
+        <div class="label">Total users</div>
+        <div class="value">@Model.TotalUsers</div>
+        <div class="icon"><i class="fas fa-users"></i></div>
     </div>
-    <div class="col-md-2">
-        <div class="card text-white bg-dark">
-            <div class="card-body text-center">
-                <h3>@Model.TotalCitizens</h3>
-                <h6 class="card-title">Citizens</h6>
-            </div>
-        </div>
+    <div class="metric-tile gradient-rose">
+        <div class="label">Citizens</div>
+        <div class="value">@Model.TotalCitizens</div>
+        <div class="icon"><i class="fas fa-people-group"></i></div>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Issues by Category</h5>
+<div class="row g-4">
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Issues by category</div>
+                    <div class="subtitle">Top drivers of community feedback</div>
+                </div>
             </div>
-            <div class="card-body">
-                @if (Model.CategoryStats.Any())
-                {
-                    foreach (var category in Model.CategoryStats)
+            @if (Model.CategoryStats.Any())
+            {
+                <div class="list-modern">
+                    @foreach (var category in Model.CategoryStats)
                     {
-                        <div class="d-flex justify-content-between align-items-center mb-2">
-                            <div class="d-flex align-items-center">
-                                <div class="rounded-circle me-2" style="width: 12px; height: 12px; background-color: @category.CategoryColor;"></div>
-                                <span>@category.CategoryName</span>
+                        <div class="list-modern-item d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="rounded-circle" style="width: 14px; height: 14px; background-color: @category.CategoryColor;"></div>
+                                <span class="text-white">@category.CategoryName</span>
                             </div>
-                            <div>
-                                <span class="badge bg-secondary">@category.Count</span>
-                                <small class="text-muted">(@category.Percentage.ToString("F1")%)</small>
+                            <div class="text-end">
+                                <span class="badge-soft">@category.Count</span>
+                                <div class="text-white-50 small">@category.Percentage.ToString("F1")%</div>
                             </div>
                         </div>
                     }
-                }
-                else
-                {
-                    <p class="text-muted text-center">No categories found</p>
-                }
-            </div>
+                </div>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No categories found</p>
+                </div>
+            }
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Recent Issues</h5>
+    <div class="col-lg-6">
+        <div class="glass-card p-4 h-100">
+            <div class="section-heading">
+                <div>
+                    <div class="title">Recent issues</div>
+                    <div class="subtitle">Newest reports entering the queue</div>
+                </div>
+                <a asp-controller="Admin" asp-action="Issues" class="btn btn-soft-light btn-sm px-3">View all</a>
             </div>
-            <div class="card-body">
-                @if (Model.RecentIssues.Any())
-                {
-                    <div class="list-group list-group-flush">
-                        @foreach (var issue in Model.RecentIssues.Take(5))
-                        {
-                            <div class="list-group-item d-flex justify-content-between align-items-start">
-                                <div class="ms-2 me-auto">
-                                    <div class="fw-bold">@issue.Title</div>
-                                    <small class="text-muted">@issue.Location • @issue.ReporterName</small>
+            @if (Model.RecentIssues.Any())
+            {
+                <div class="list-modern">
+                    @foreach (var issue in Model.RecentIssues.Take(5))
+                    {
+                        <div class="list-modern-item">
+                            <div class="d-flex justify-content-between align-items-start gap-3">
+                                <div>
+                                    <div class="text-white fw-semibold">@issue.Title</div>
+                                    <small class="text-white-50">@issue.Location • @issue.ReporterName</small>
                                 </div>
                                 <div class="text-end">
-                                    <span class="badge bg-@(issue.Status switch
+                                    <span class="chip chip-status @(issue.Status switch
                                     {
-                                        IssueStatus.Pending => "warning",
-                                        IssueStatus.InProgress => "info",
-                                        IssueStatus.Resolved => "success",
-                                        IssueStatus.Rejected => "danger",
-                                        _ => "secondary"
-                                    }) rounded-pill">
-                                        @issue.Status
+                                        IssueStatus.Pending => "pending",
+                                        IssueStatus.InProgress => "in-progress",
+                                        IssueStatus.Resolved => "resolved",
+                                        IssueStatus.Rejected => "rejected",
+                                        _ => string.Empty
+                                    })">
+                                        <i class="fas fa-signal"></i>@issue.Status
                                     </span>
-                                    <br>
-                                    <small class="text-muted">@issue.CreatedAt.ToString("MMM dd")</small>
+                                    <div class="text-white-50 small mt-2">@issue.CreatedAt.ToString("MMM dd")</div>
                                 </div>
                             </div>
-                        }
-                    </div>
-                    <div class="text-center mt-3">
-                        <a asp-controller="Admin" asp-action="Issues" class="btn btn-sm btn-outline-primary">View All Issues</a>
-                    </div>
-                }
-                else
-                {
-                    <p class="text-muted text-center">No issues found</p>
-                }
-            </div>
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="empty-state text-center py-4">
+                    <p class="text-white-50 mb-0">No issues found</p>
+                </div>
+            }
         </div>
     </div>
 </div>
 
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Recent Users</h5>
-            </div>
-            <div class="card-body">
-                @if (Model.RecentUsers.Any())
-                {
-                    <div class="table-responsive">
-                        <table class="table table-striped">
-                            <thead>
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Email</th>
-                                    <th>Role</th>
-                                    <th>Joined</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var user in Model.RecentUsers)
-                                {
-                                    <tr>
-                                        <td>@user.Name</td>
-                                        <td>@user.Email</td>
-                                        <td>
-                                            <span class="badge bg-@(user.Role switch
-                                            {
-                                                UserRole.Admin => "danger",
-                                                UserRole.Official => "warning",
-                                                UserRole.Citizen => "info",
-                                                _ => "secondary"
-                                            })">
-                                                @user.Role
-                                            </span>
-                                        </td>
-                                        <td>@user.CreatedAt.ToString("MMM dd, yyyy")</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                }
-                else
-                {
-                    <p class="text-muted text-center">No users found</p>
-                }
-            </div>
+<div class="glass-card p-4 mt-4">
+    <div class="section-heading">
+        <div>
+            <div class="title">Recent users</div>
+            <div class="subtitle">Latest residents and officials joining the platform</div>
         </div>
     </div>
+    @if (Model.RecentUsers.Any())
+    {
+        <div class="table-responsive table-modern">
+            <table class="table align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Email</th>
+                        <th scope="col">Role</th>
+                        <th scope="col">Joined</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var user in Model.RecentUsers)
+                    {
+                        <tr>
+                            <td class="text-white">@user.Name</td>
+                            <td class="text-white-50">@user.Email</td>
+                            <td>
+                                <span class="chip chip-status @(user.Role switch
+                                {
+                                    UserRole.Admin => "rejected",
+                                    UserRole.Official => "pending",
+                                    UserRole.Citizen => "in-progress",
+                                    _ => string.Empty
+                                })">
+                                    <i class="fas fa-user-tag"></i>@user.Role
+                                </span>
+                            </td>
+                            <td class="text-white-50">@user.CreatedAt.ToString("MMM dd, yyyy")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        <div class="empty-state text-center py-4">
+            <p class="text-white-50 mb-0">No users found</p>
+        </div>
+    }
 </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Dashboard/Index.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Dashboard/Index.cshtml
@@ -3,159 +3,118 @@
     ViewData["Title"] = "Dashboard";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2>Welcome back, @Model.UserName!</h2>
-    <a asp-controller="Issues" asp-action="Create" class="btn btn-primary">
-        <i class="fas fa-plus me-2"></i>Report New Issue
-    </a>
-</div>
-
-<div class="row mb-4">
-    <div class="col-md-3">
-        <div class="card text-white bg-primary">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="card-title">Total Issues</h6>
-                        <h3 class="mb-0">@Model.TotalIssues</h3>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="fas fa-tasks fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+<div class="page-header">
+    <div>
+        <h1 class="page-title">Welcome back, @Model.UserName!</h1>
+        <p class="page-subtitle">Here&apos;s a snapshot of the community work you&apos;re driving. Dive into open items, monitor progress, and celebrate resolved wins.</p>
     </div>
-    <div class="col-md-3">
-        <div class="card text-white bg-warning">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="card-title">Pending</h6>
-                        <h3 class="mb-0">@Model.PendingIssues</h3>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="fas fa-clock fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-white bg-info">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="card-title">In Progress</h6>
-                        <h3 class="mb-0">@Model.InProgressIssues</h3>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="fas fa-spinner fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-3">
-        <div class="card text-white bg-success">
-            <div class="card-body">
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <h6 class="card-title">Resolved</h6>
-                        <h3 class="mb-0">@Model.ResolvedIssues</h3>
-                    </div>
-                    <div class="align-self-center">
-                        <i class="fas fa-check-circle fa-2x"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div class="page-actions">
+        <a asp-controller="Issues" asp-action="Create" class="btn btn-primary btn-lg px-4">
+            <i class="fas fa-plus me-2"></i>Report new issue
+        </a>
     </div>
 </div>
 
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Recent Issues</h5>
-            </div>
-            <div class="card-body">
-                @if (Model.RecentIssues.Any())
-                {
-                    <div class="table-responsive">
-                        <table class="table table-striped">
-                            <thead>
-                                <tr>
-                                    <th>Title</th>
-                                    <th>Category</th>
-                                    <th>Status</th>
-                                    <th>Priority</th>
-                                    <th>Created</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (var issue in Model.RecentIssues)
+<div class="metric-grid">
+    <div class="metric-tile gradient-blue">
+        <div class="label">Total issues</div>
+        <div class="value">@Model.TotalIssues</div>
+        <div class="icon"><i class="fas fa-tasks"></i></div>
+    </div>
+    <div class="metric-tile gradient-amber">
+        <div class="label">Pending</div>
+        <div class="value">@Model.PendingIssues</div>
+        <div class="icon"><i class="fas fa-clock"></i></div>
+    </div>
+    <div class="metric-tile gradient-cyan">
+        <div class="label">In progress</div>
+        <div class="value">@Model.InProgressIssues</div>
+        <div class="icon"><i class="fas fa-spinner"></i></div>
+    </div>
+    <div class="metric-tile gradient-emerald">
+        <div class="label">Resolved</div>
+        <div class="value">@Model.ResolvedIssues</div>
+        <div class="icon"><i class="fas fa-check-circle"></i></div>
+    </div>
+</div>
+
+<div class="glass-card p-4">
+    <div class="section-heading">
+        <div>
+            <div class="title">Recent issues</div>
+            <div class="subtitle">Latest activity from your submissions</div>
+        </div>
+    </div>
+    @if (Model.RecentIssues.Any())
+    {
+        <div class="table-responsive table-modern">
+            <table class="table align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th scope="col">Title</th>
+                        <th scope="col">Category</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Priority</th>
+                        <th scope="col">Created</th>
+                        <th scope="col" class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var issue in Model.RecentIssues)
+                    {
+                        <tr>
+                            <td class="text-white">
+                                <strong>@issue.Title</strong>
+                                <div class="text-white-50 small">@(issue.Description.Length > 100 ? issue.Description.Substring(0, 100) + "..." : issue.Description)</div>
+                            </td>
+                            <td>
+                                <span class="chip chip-category" style="background: linear-gradient(135deg, @issue.Category.Color, rgba(255,255,255,0.15));">
+                                    <i class="fas fa-layer-group"></i>@issue.Category.Name
+                                </span>
+                            </td>
+                            <td>
+                                <span class="chip chip-status @(issue.Status switch
                                 {
-                                    <tr>
-                                        <td>
-                                            <strong>@issue.Title</strong>
-                                            <br>
-                                            <small class="text-muted">@(issue.Description.Length > 100 ? issue.Description.Substring(0, 100) + "..." : issue.Description)</small>
-                                        </td>
-                                        <td>
-                                            <span class="badge" style="background-color: @issue.Category.Color">
-                                                @issue.Category.Name
-                                            </span>
-                                        </td>
-                                        <td>
-                                            <span class="badge bg-@(issue.Status switch
-                                            {
-                                                IssueStatus.Pending => "warning",
-                                                IssueStatus.InProgress => "info",
-                                                IssueStatus.Resolved => "success",
-                                                IssueStatus.Rejected => "danger",
-                                                _ => "secondary"
-                                            })">
-                                                @issue.Status
-                                            </span>
-                                        </td>
-                                        <td>
-                                            <span class="badge bg-@(issue.Priority switch
-                                            {
-                                                Priority.Low => "secondary",
-                                                Priority.Medium => "warning",
-                                                Priority.High => "danger",
-                                                Priority.Urgent => "danger",
-                                                _ => "secondary"
-                                            })">
-                                                @issue.Priority
-                                            </span>
-                                        </td>
-                                        <td>@issue.CreatedAt.ToString("MMM dd, yyyy")</td>
-                                        <td>
-                                            <a asp-controller="Issues" asp-action="Details" asp-route-id="@issue.Id" class="btn btn-sm btn-outline-primary">
-                                                <i class="fas fa-eye me-1"></i>View
-                                            </a>
-                                        </td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    </div>
-                }
-                else
-                {
-                    <div class="text-center py-5">
-                        <i class="fas fa-inbox fa-3x text-muted mb-3"></i>
-                        <h5>No issues reported yet</h5>
-                        <p class="text-muted">Start by reporting your first community issue.</p>
-                        <a asp-controller="Issues" asp-action="Create" class="btn btn-primary">
-                            <i class="fas fa-plus me-2"></i>Report Issue
-                        </a>
-                    </div>
-                }
-            </div>
+                                    IssueStatus.Pending => "pending",
+                                    IssueStatus.InProgress => "in-progress",
+                                    IssueStatus.Resolved => "resolved",
+                                    IssueStatus.Rejected => "rejected",
+                                    _ => string.Empty
+                                })">
+                                    <i class="fas fa-signal"></i>@issue.Status
+                                </span>
+                            </td>
+                            <td>
+                                <span class="chip chip-priority @(issue.Priority switch
+                                {
+                                    Priority.High => "high",
+                                    Priority.Urgent => "urgent",
+                                    _ => string.Empty
+                                })">
+                                    <i class="fas fa-bolt"></i>@issue.Priority
+                                </span>
+                            </td>
+                            <td class="text-white-50">@issue.CreatedAt.ToString("MMM dd, yyyy")</td>
+                            <td class="text-end">
+                                <a asp-controller="Issues" asp-action="Details" asp-route-id="@issue.Id" class="btn btn-outline-primary btn-sm rounded-pill px-3">
+                                    <i class="fas fa-eye me-1"></i>View
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
         </div>
-    </div>
+    }
+    else
+    {
+        <div class="empty-state text-center">
+            <i class="fas fa-inbox fa-3x text-white-50 mb-3"></i>
+            <h5 class="text-white mb-2">No issues reported yet</h5>
+            <p class="text-white-50">Start by reporting your first community issue.</p>
+            <a asp-controller="Issues" asp-action="Create" class="btn btn-primary btn-lg px-4">
+                <i class="fas fa-plus me-2"></i>Report issue
+            </a>
+        </div>
+    }
 </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Home/Index.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Home/Index.cshtml
@@ -1,5 +1,7 @@
 @{
     ViewData["Title"] = "Citizen Engagement Portal";
+    ViewData["UseFullWidth"] = true;
+    ViewData["MainPaddingClass"] = "py-0";
 }
 
 <section class="hero-modern">
@@ -13,10 +15,10 @@
                     Capture, triage, and resolve community issues with a beautifully modern dashboard that keeps citizens, officials, and administrators aligned at every step.
                 </p>
                 <div class="d-flex flex-wrap gap-3">
-                    <a href="@Url.Action("Register", "Account")" class="btn btn-light btn-lg px-4">
+                    <a href="@Url.Action("Register", "Account")" class="btn btn-primary btn-lg px-4">
                         <i class="fas fa-rocket me-2"></i>Launch your portal
                     </a>
-                    <a href="@Url.Action("Login", "Account")" class="btn btn-outline-light btn-lg px-4">
+                    <a href="@Url.Action("Login", "Account")" class="btn btn-soft-light btn-lg px-4 text-white">
                         Explore the experience
                     </a>
                 </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Create.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Create.cshtml
@@ -3,108 +3,96 @@
     ViewData["Title"] = "Report New Issue";
 }
 
-<div class="row">
-    <div class="col-12">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <h2>Report New Issue</h2>
-            <a asp-controller="Dashboard" asp-action="Index" class="btn btn-outline-secondary">
-                <i class="fas fa-arrow-left me-2"></i>Back to Dashboard
-            </a>
-        </div>
+<div class="page-header">
+    <div>
+        <h1 class="page-title">Report a new community issue</h1>
+        <p class="page-subtitle">Share the details we need to mobilize the right teams quickly. Photos, precise locations, and context help accelerate resolutions.</p>
+    </div>
+    <div class="page-actions">
+        <a asp-controller="Dashboard" asp-action="Index" class="btn btn-soft-light">
+            <i class="fas fa-arrow-left me-2"></i>Back to dashboard
+        </a>
     </div>
 </div>
 
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Issue Details</h5>
-                <p class="text-muted mb-0">Provide detailed information about the issue you want to report</p>
-            </div>
-            <div class="card-body">
-                <form asp-action="Create" method="post" enctype="multipart/form-data">
-                    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-                    
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="Title" class="form-label"></label>
-                                <input asp-for="Title" class="form-control" placeholder="Brief description of the issue" />
-                                <span asp-validation-for="Title" class="text-danger"></span>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="CategoryId" class="form-label"></label>
-                                <select asp-for="CategoryId" asp-items="@(new SelectList(Model.Categories, "Id", "Name"))" class="form-select">
-                                    <option value="">Select a category</option>
-                                </select>
-                                <span asp-validation-for="CategoryId" class="text-danger"></span>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="Description" class="form-label"></label>
-                        <textarea asp-for="Description" class="form-control" rows="4" placeholder="Provide detailed information about the issue..."></textarea>
-                        <span asp-validation-for="Description" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="Location" class="form-label"></label>
-                                <input asp-for="Location" class="form-control" placeholder="Enter the address or location" />
-                                <span asp-validation-for="Location" class="text-danger"></span>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="Priority" class="form-label"></label>
-                                <select asp-for="Priority" class="form-select">
-                                    <option value="@Priority.Low">Low</option>
-                                    <option value="@Priority.Medium" selected>Medium</option>
-                                    <option value="@Priority.High">High</option>
-                                    <option value="@Priority.Urgent">Urgent</option>
-                                </select>
-                                <span asp-validation-for="Priority" class="text-danger"></span>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="Latitude" class="form-label"></label>
-                                <input asp-for="Latitude" class="form-control" placeholder="Latitude (optional)" type="number" step="any" />
-                                <span asp-validation-for="Latitude" class="text-danger"></span>
-                            </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="mb-3">
-                                <label asp-for="Longitude" class="form-label"></label>
-                                <input asp-for="Longitude" class="form-control" placeholder="Longitude (optional)" type="number" step="any" />
-                                <span asp-validation-for="Longitude" class="text-danger"></span>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="mb-3">
-                        <label asp-for="MediaFiles" class="form-label">Attach Photos/Videos</label>
-                        <input asp-for="MediaFiles" class="form-control" type="file" multiple accept="image/*,video/*" />
-                        <div class="form-text">You can upload multiple images or videos related to the issue</div>
-                        <span asp-validation-for="MediaFiles" class="text-danger"></span>
-                    </div>
-                    
-                    <div class="d-flex justify-content-between">
-                        <a asp-controller="Dashboard" asp-action="Index" class="btn btn-outline-secondary">Cancel</a>
-                        <button type="submit" class="btn btn-primary">
-                            <i class="fas fa-paper-plane me-2"></i>Submit Issue
-                        </button>
-                    </div>
-                </form>
+<div class="form-card card">
+    <div class="card-header border-0">
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-3">
+            <div>
+                <span class="badge-soft text-uppercase">Issue intake</span>
+                <h2 class="h3 text-white mt-2 mb-2">Tell us what&apos;s happening</h2>
+                <p class="text-white-50 mb-0">Provide as much context as possible so city teams can triage and respond without delay.</p>
             </div>
         </div>
+    </div>
+    <div class="card-body">
+        <form asp-action="Create" method="post" enctype="multipart/form-data" class="row g-4">
+            <div class="col-12">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Title" class="form-label fw-semibold">Issue title</label>
+                <input asp-for="Title" class="form-control" placeholder="Brief description of the issue" />
+                <span asp-validation-for="Title" class="text-danger"></span>
+            </div>
+            <div class="col-md-6">
+                <label asp-for="CategoryId" class="form-label fw-semibold">Category</label>
+                <select asp-for="CategoryId" asp-items="@(new SelectList(Model.Categories, "Id", "Name"))" class="form-select">
+                    <option value="">Select a category</option>
+                </select>
+                <span asp-validation-for="CategoryId" class="text-danger"></span>
+            </div>
+
+            <div class="col-12">
+                <label asp-for="Description" class="form-label fw-semibold">Description</label>
+                <textarea asp-for="Description" class="form-control" rows="4" placeholder="Share detailed information about the issue..."></textarea>
+                <span asp-validation-for="Description" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Location" class="form-label fw-semibold">Location</label>
+                <input asp-for="Location" class="form-control" placeholder="Enter the address or location" />
+                <span asp-validation-for="Location" class="text-danger"></span>
+            </div>
+            <div class="col-md-6">
+                <label asp-for="Priority" class="form-label fw-semibold">Priority</label>
+                <select asp-for="Priority" class="form-select">
+                    <option value="@Priority.Low">Low</option>
+                    <option value="@Priority.Medium" selected>Medium</option>
+                    <option value="@Priority.High">High</option>
+                    <option value="@Priority.Urgent">Urgent</option>
+                </select>
+                <span asp-validation-for="Priority" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Latitude" class="form-label fw-semibold">Latitude</label>
+                <input asp-for="Latitude" class="form-control" placeholder="Latitude (optional)" type="number" step="any" />
+                <span asp-validation-for="Latitude" class="text-danger"></span>
+            </div>
+            <div class="col-md-6">
+                <label asp-for="Longitude" class="form-label fw-semibold">Longitude</label>
+                <input asp-for="Longitude" class="form-control" placeholder="Longitude (optional)" type="number" step="any" />
+                <span asp-validation-for="Longitude" class="text-danger"></span>
+            </div>
+
+            <div class="col-12">
+                <label asp-for="MediaFiles" class="form-label fw-semibold">Attach photos or videos</label>
+                <input asp-for="MediaFiles" class="form-control" type="file" multiple accept="image/*,video/*" />
+                <div class="form-text text-white-50">You can upload multiple files to give responders more context.</div>
+                <span asp-validation-for="MediaFiles" class="text-danger"></span>
+            </div>
+
+            <div class="col-12 d-flex justify-content-between align-items-center flex-wrap gap-3 pt-3">
+                <a asp-controller="Dashboard" asp-action="Index" class="btn btn-soft-light px-4">
+                    Cancel
+                </a>
+                <button type="submit" class="btn btn-primary btn-lg px-4">
+                    <i class="fas fa-paper-plane me-2"></i>Submit issue
+                </button>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Details.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Details.cshtml
@@ -3,213 +3,237 @@
     ViewData["Title"] = "Issue Details";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2>Issue Details</h2>
-    <a asp-controller="Dashboard" asp-action="Index" class="btn btn-outline-secondary">
-        <i class="fas fa-arrow-left me-2"></i>Back to Dashboard
-    </a>
-</div>
-
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <div class="d-flex justify-content-between align-items-start">
-                    <div>
-                        <h3 class="card-title">@Model.Title</h3>
-                        <p class="card-text text-muted mb-0">@Model.Description</p>
-                        <small class="text-muted">
-                            Reported by @Model.Citizen.Name (@Model.Citizen.Email) on @Model.CreatedAt.ToString("MMM dd, yyyy at HH:mm")
-                        </small>
-                    </div>
-                    <div class="d-flex gap-2">
-                        <span class="badge" style="background-color: @Model.Category.Color">
-                            @Model.Category.Name
-                        </span>
-                        <span class="badge bg-@(Model.Status switch
-                        {
-                            IssueStatus.Pending => "warning",
-                            IssueStatus.InProgress => "info",
-                            IssueStatus.Resolved => "success",
-                            IssueStatus.Rejected => "danger",
-                            _ => "secondary"
-                        })">
-                            @Model.Status
-                        </span>
-                        <span class="badge bg-@(Model.Priority switch
-                        {
-                            Priority.Low => "secondary",
-                            Priority.Medium => "warning",
-                            Priority.High => "danger",
-                            Priority.Urgent => "danger",
-                            _ => "secondary"
-                        })">
-                            @Model.Priority
-                        </span>
-                    </div>
-                </div>
-            </div>
-            <div class="card-body">
-                <div class="row mb-4">
-                    <div class="col-md-6">
-                        <h6>Location Information</h6>
-                        <p><i class="fas fa-map-marker-alt me-2"></i>@Model.Location</p>
-                        @if (Model.Latitude.HasValue && Model.Longitude.HasValue)
-                        {
-                            <p><i class="fas fa-globe me-2"></i>Coordinates: @Model.Latitude.Value.ToString("F4"), @Model.Longitude.Value.ToString("F4")</p>
-                        }
-                    </div>
-                    <div class="col-md-6">
-                        <h6>Timeline</h6>
-                        <p><i class="fas fa-calendar-plus me-2"></i>Created: @Model.CreatedAt.ToString("MMM dd, yyyy")</p>
-                        @if (Model.AssignedAt.HasValue)
-                        {
-                            <p><i class="fas fa-user-check me-2"></i>Assigned: @Model.AssignedAt.Value.ToString("MMM dd, yyyy")</p>
-                        }
-                        @if (Model.ResolvedAt.HasValue)
-                        {
-                            <p><i class="fas fa-check-circle me-2"></i>Resolved: @Model.ResolvedAt.Value.ToString("MMM dd, yyyy")</p>
-                        }
-                    </div>
-                </div>
-
-                @if (Model.Assignee != null)
-                {
-                    <div class="row mb-4">
-                        <div class="col-12">
-                            <h6>Assigned To</h6>
-                            <p><i class="fas fa-user me-2"></i>@Model.Assignee.Name (@Model.Assignee.Email)</p>
-                        </div>
-                    </div>
-                }
-
-                @if (Model.Media.Any())
-                {
-                    <div class="row mb-4">
-                        <div class="col-12">
-                            <h6>Attached Media</h6>
-                            <div class="row">
-                                @foreach (var media in Model.Media)
-                                {
-                                    <div class="col-md-3 mb-3">
-                                        <div class="card">
-                                            @if (media.Type == MediaType.Image)
-                                            {
-                                                <img src="@media.Url" class="card-img-top" alt="Issue media" style="height: 150px; object-fit: cover;" />
-                                            }
-                                            else
-                                            {
-                                                <div class="card-img-top d-flex align-items-center justify-content-center" style="height: 150px; background-color: #f8f9fa;">
-                                                    <i class="fas fa-video fa-3x text-muted"></i>
-                                                </div>
-                                            }
-                                            <div class="card-body text-center p-2">
-                                                <small class="text-muted">@media.Type</small>
-                                            </div>
-                                        </div>
-                                    </div>
-                                }
-                            </div>
-                        </div>
-                    </div>
-                }
-
-                <!-- Admin Actions -->
-                @if (Model.CanAssign || Model.CanResolve)
-                {
-                    <div class="row mb-4">
-                        <div class="col-12">
-                            <h6>Actions</h6>
-                            <div class="d-flex gap-2">
-                                @if (Model.CanAssign && Model.Status == IssueStatus.Pending)
-                                {
-                                    <a asp-controller="Admin" asp-action="AssignIssue" asp-route-id="@Model.Id" class="btn btn-primary">
-                                        <i class="fas fa-user-plus me-2"></i>Assign Issue
-                                    </a>
-                                }
-                                @if (Model.CanResolve && Model.Status != IssueStatus.Resolved)
-                                {
-                                    <form asp-controller="Admin" asp-action="UpdateIssueStatus" method="post" class="d-inline">
-                                        <input type="hidden" name="id" value="@Model.Id" />
-                                        <input type="hidden" name="status" value="@IssueStatus.Resolved" />
-                                        <button type="submit" class="btn btn-success">
-                                            <i class="fas fa-check me-2"></i>Mark Resolved
-                                        </button>
-                                    </form>
-                                }
-                                @if (Model.CanResolve && Model.Status == IssueStatus.Resolved)
-                                {
-                                    <form asp-controller="Admin" asp-action="UpdateIssueStatus" method="post" class="d-inline">
-                                        <input type="hidden" name="id" value="@Model.Id" />
-                                        <input type="hidden" name="status" value="@IssueStatus.InProgress" />
-                                        <button type="submit" class="btn btn-warning">
-                                            <i class="fas fa-undo me-2"></i>Reopen Issue
-                                        </button>
-                                    </form>
-                                }
-                            </div>
-                        </div>
-                    </div>
-                }
-            </div>
-        </div>
+<div class="page-header">
+    <div>
+        <h1 class="page-title">@Model.Title</h1>
+        <p class="page-subtitle">Filed by @Model.Citizen.Name on @Model.CreatedAt.ToString("MMM dd, yyyy") • Category @Model.Category.Name</p>
+    </div>
+    <div class="page-actions">
+        <a asp-controller="Dashboard" asp-action="Index" class="btn btn-soft-light">
+            <i class="fas fa-arrow-left me-2"></i>Back to dashboard
+        </a>
     </div>
 </div>
 
-<!-- Comments Section -->
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">Comments (@Model.Comments.Count)</h5>
+<div class="issue-card mb-5">
+    <div class="issue-card-content">
+        <div class="d-flex flex-wrap justify-content-between gap-3">
+            <div class="flex-grow-1">
+                <h2 class="h4 text-white mb-3">Issue summary</h2>
+                <p class="text-white-50 mb-0">@Model.Description</p>
             </div>
-            <div class="card-body">
-                <!-- Add Comment Form -->
-                <form asp-controller="Issues" asp-action="AddComment" method="post" class="mb-4">
-                    <input type="hidden" name="issueId" value="@Model.Id" />
-                    <div class="mb-3">
-                        <label class="form-label">Add a Comment</label>
-                        <textarea name="content" class="form-control" rows="3" placeholder="Share your thoughts or updates about this issue..." required></textarea>
-                    </div>
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-paper-plane me-2"></i>Post Comment
-                    </button>
-                </form>
-
-                <hr>
-
-                <!-- Comments List -->
-                @if (Model.Comments.Any())
-                {
-                    <div class="comments-list">
-                        @foreach (var comment in Model.Comments)
-                        {
-                            <div class="comment mb-3">
-                                <div class="d-flex">
-                                    <div class="flex-shrink-0">
-                                        <div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center" style="width: 40px; height: 40px;">
-                                            @(comment.Author.Name?.FirstOrDefault() ?? comment.Author.Email.FirstOrDefault())
-                                        </div>
-                                    </div>
-                                    <div class="flex-grow-1 ms-3">
-                                        <div class="d-flex justify-content-between">
-                                            <h6 class="mb-1">@comment.Author.Name</h6>
-                                            <small class="text-muted">@comment.CreatedAt.ToString("MMM dd, yyyy HH:mm")</small>
-                                        </div>
-                                        <p class="mb-0">@comment.Content</p>
-                                    </div>
-                                </div>
-                            </div>
-                        }
-                    </div>
-                }
-                else
-                {
-                    <div class="text-center py-3">
-                        <p class="text-muted mb-0">No comments yet. Be the first to comment!</p>
-                    </div>
-                }
+            <div class="text-end">
+                <div class="issue-meta justify-content-end">
+                    <span class="chip chip-category" style="background: linear-gradient(135deg, @Model.Category.Color, rgba(255,255,255,0.15));">
+                        <i class="fas fa-layer-group"></i>@Model.Category.Name
+                    </span>
+                    <span class="chip chip-status @(Model.Status switch
+                    {
+                        IssueStatus.Pending => "pending",
+                        IssueStatus.InProgress => "in-progress",
+                        IssueStatus.Resolved => "resolved",
+                        IssueStatus.Rejected => "rejected",
+                        _ => string.Empty
+                    })">
+                        <i class="fas fa-signal"></i>@Model.Status
+                    </span>
+                    <span class="chip chip-priority @(Model.Priority switch
+                    {
+                        Priority.High => "high",
+                        Priority.Urgent => "urgent",
+                        _ => string.Empty
+                    })">
+                        <i class="fas fa-bolt"></i>@Model.Priority
+                    </span>
+                </div>
+                <small class="text-white-50 d-block">Report ID: @Model.Id</small>
             </div>
         </div>
+
+        <div class="card-section-divider"></div>
+
+        <div class="row g-4">
+            <div class="col-lg-4">
+                <div class="glass-card p-4 h-100">
+                    <div class="section-heading">
+                        <div class="title">Location</div>
+                        <div class="subtitle">Where the issue exists</div>
+                    </div>
+                    <p class="text-white-75 mb-3"><i class="fas fa-map-marker-alt me-2"></i>@Model.Location</p>
+                    @if (Model.Latitude.HasValue && Model.Longitude.HasValue)
+                    {
+                        <div class="badge-soft d-inline-flex align-items-center gap-2">
+                            <i class="fas fa-globe"></i>
+                            @Model.Latitude.Value.ToString("F4"), @Model.Longitude.Value.ToString("F4")
+                        </div>
+                    }
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="glass-card p-4 h-100">
+                    <div class="section-heading">
+                        <div class="title">Timeline</div>
+                        <div class="subtitle">Key milestones</div>
+                    </div>
+                    <ul class="list-unstyled text-white-75 mb-0">
+                        <li class="mb-2"><i class="fas fa-calendar-plus me-2"></i>Created: @Model.CreatedAt.ToString("MMM dd, yyyy")</li>
+                        @if (Model.AssignedAt.HasValue)
+                        {
+                            <li class="mb-2"><i class="fas fa-user-check me-2"></i>Assigned: @Model.AssignedAt.Value.ToString("MMM dd, yyyy")</li>
+                        }
+                        @if (Model.ResolvedAt.HasValue)
+                        {
+                            <li class="mb-2"><i class="fas fa-check-circle me-2"></i>Resolved: @Model.ResolvedAt.Value.ToString("MMM dd, yyyy")</li>
+                        }
+                    </ul>
+                </div>
+            </div>
+            <div class="col-lg-4">
+                <div class="glass-card p-4 h-100">
+                    <div class="section-heading">
+                        <div class="title">Assigned team</div>
+                        <div class="subtitle">Who&apos;s handling it</div>
+                    </div>
+                    @if (Model.Assignee != null)
+                    {
+                        <div class="d-flex align-items-center gap-3">
+                            <div class="avatar-placeholder">
+                                <i class="fas fa-user"></i>
+                            </div>
+                            <div>
+                                <div class="text-white fw-semibold">@Model.Assignee.Name</div>
+                                <small class="text-white-50">@Model.Assignee.Email</small>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-white-50 mb-0">Not yet assigned</p>
+                    }
+                </div>
+            </div>
+        </div>
+
+        @if (Model.Media.Any())
+        {
+            <div class="card-section-divider"></div>
+            <div class="section-heading">
+                <div>
+                    <div class="title">Attached media</div>
+                    <div class="subtitle">Supporting visuals from the field</div>
+                </div>
+            </div>
+            <div class="row g-3">
+                @foreach (var media in Model.Media)
+                {
+                    <div class="col-md-3 col-sm-6">
+                        <div class="glass-card overflow-hidden h-100">
+                            @if (media.Type == MediaType.Image)
+                            {
+                                <img src="@media.Url" class="w-100" alt="Issue media" style="height: 160px; object-fit: cover;" />
+                            }
+                            else
+                            {
+                                <div class="d-flex align-items-center justify-content-center" style="height: 160px; background: rgba(148, 163, 184, 0.1);">
+                                    <i class="fas fa-video fa-2x text-white-50"></i>
+                                </div>
+                            }
+                            <div class="p-3 text-center text-white-50 text-uppercase small">@media.Type</div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+
+        @if (Model.CanAssign || Model.CanResolve)
+        {
+            <div class="card-section-divider"></div>
+            <div class="section-heading">
+                <div class="title">Actions</div>
+                <div class="subtitle">Update status or assign owners</div>
+            </div>
+            <div class="issue-actions">
+                @if (Model.CanAssign && Model.Status == IssueStatus.Pending)
+                {
+                    <a asp-controller="Admin" asp-action="AssignIssue" asp-route-id="@Model.Id" class="btn btn-primary">
+                        <i class="fas fa-user-plus me-2"></i>Assign issue
+                    </a>
+                }
+                @if (Model.CanResolve && Model.Status != IssueStatus.Resolved)
+                {
+                    <form asp-controller="Admin" asp-action="UpdateIssueStatus" method="post" class="d-inline">
+                        <input type="hidden" name="id" value="@Model.Id" />
+                        <input type="hidden" name="status" value="@IssueStatus.Resolved" />
+                        <button type="submit" class="btn btn-success">
+                            <i class="fas fa-check me-2"></i>Mark resolved
+                        </button>
+                    </form>
+                }
+                @if (Model.CanResolve && Model.Status == IssueStatus.Resolved)
+                {
+                    <form asp-controller="Admin" asp-action="UpdateIssueStatus" method="post" class="d-inline">
+                        <input type="hidden" name="id" value="@Model.Id" />
+                        <input type="hidden" name="status" value="@IssueStatus.InProgress" />
+                        <button type="submit" class="btn btn-warning">
+                            <i class="fas fa-undo me-2"></i>Reopen issue
+                        </button>
+                    </form>
+                }
+            </div>
+        }
+    </div>
+</div>
+
+<div class="form-card card">
+    <div class="card-header border-0">
+        <div class="d-flex justify-content-between align-items-center">
+            <h3 class="h4 text-white mb-0">Comments (@Model.Comments.Count)</h3>
+        </div>
+    </div>
+    <div class="card-body">
+        <form asp-controller="Issues" asp-action="AddComment" method="post" class="mb-4">
+            <input type="hidden" name="issueId" value="@Model.Id" />
+            <label class="form-label fw-semibold">Add a comment</label>
+            <textarea name="content" class="form-control" rows="3" placeholder="Share your thoughts or updates about this issue..." required></textarea>
+            <div class="d-flex justify-content-end mt-3">
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-paper-plane me-2"></i>Post comment
+                </button>
+            </div>
+        </form>
+
+        <div class="card-section-divider"></div>
+
+        @if (Model.Comments.Any())
+        {
+            <div class="list-modern">
+                @foreach (var comment in Model.Comments)
+                {
+                    <div class="list-modern-item">
+                        <div class="d-flex gap-3">
+                            <div class="comment-author">
+                                @(comment.Author.Name?.FirstOrDefault() ?? comment.Author.Email.FirstOrDefault())
+                            </div>
+                            <div class="flex-grow-1">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <div class="text-white fw-semibold">@comment.Author.Name</div>
+                                        <small class="text-white-50">@comment.Author.Email</small>
+                                    </div>
+                                    <small class="text-white-50">@comment.CreatedAt.ToString("MMM dd, yyyy HH:mm")</small>
+                                </div>
+                                <p class="text-white-75 mb-0 mt-2">@comment.Content</p>
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+        else
+        {
+            <div class="empty-state text-center py-4">
+                <p class="text-white-50 mb-0">No comments yet. Be the first to contribute.</p>
+            </div>
+        }
     </div>
 </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Index.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Issues/Index.cshtml
@@ -3,87 +3,98 @@
     ViewData["Title"] = "My Issues";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <h2>My Issues</h2>
-    <a asp-controller="Issues" asp-action="Create" class="btn btn-primary">
-        <i class="fas fa-plus me-2"></i>Report New Issue
-    </a>
+<div class="page-header">
+    <div>
+        <h1 class="page-title">My Issues</h1>
+        <p class="page-subtitle">Track every report you have submitted and keep tabs on the work happening around your community.</p>
+    </div>
+    <div class="page-actions">
+        <a asp-controller="Issues" asp-action="Create" class="btn btn-primary btn-lg px-4">
+            <i class="fas fa-plus me-2"></i>Report New Issue
+        </a>
+    </div>
 </div>
 
 <!-- Filter Tabs -->
-<div class="mb-4">
-    <ul class="nav nav-tabs">
+<div class="d-flex flex-wrap align-items-center gap-3 mb-4">
+    <ul class="nav nav-tabs tab-modern">
         <li class="nav-item">
-            <a class="nav-link @(Model.CurrentFilter == null ? "active" : "")" asp-controller="Issues" asp-action="Index">All Issues (@Model.Issues.Count)</a>
+            <a class="nav-link @(Model.CurrentFilter == null ? "active" : "")" asp-controller="Issues" asp-action="Index">
+                All Issues <span class="badge-soft ms-2">@Model.Issues.Count</span>
+            </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link @(Model.CurrentFilter == IssueStatus.Pending ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.Pending">Pending (@Model.Issues.Count(i => i.Status == IssueStatus.Pending))</a>
+            <a class="nav-link @(Model.CurrentFilter == IssueStatus.Pending ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.Pending">
+                Pending <span class="badge-soft status-pending ms-2">@Model.Issues.Count(i => i.Status == IssueStatus.Pending)</span>
+            </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link @(Model.CurrentFilter == IssueStatus.InProgress ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.InProgress">In Progress (@Model.Issues.Count(i => i.Status == IssueStatus.InProgress))</a>
+            <a class="nav-link @(Model.CurrentFilter == IssueStatus.InProgress ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.InProgress">
+                In Progress <span class="badge-soft status-progress ms-2">@Model.Issues.Count(i => i.Status == IssueStatus.InProgress)</span>
+            </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link @(Model.CurrentFilter == IssueStatus.Resolved ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.Resolved">Resolved (@Model.Issues.Count(i => i.Status == IssueStatus.Resolved))</a>
+            <a class="nav-link @(Model.CurrentFilter == IssueStatus.Resolved ? "active" : "")" asp-controller="Issues" asp-action="Index" asp-route-status="@IssueStatus.Resolved">
+                Resolved <span class="badge-soft status-resolved ms-2">@Model.Issues.Count(i => i.Status == IssueStatus.Resolved)</span>
+            </a>
         </li>
     </ul>
+    @if (Model.CurrentFilter.HasValue)
+    {
+        <span class="text-white-50">Showing <strong>@Model.CurrentFilter</strong> requests</span>
+    }
 </div>
 
 <!-- Issues List -->
 @if (Model.Issues.Any())
 {
-    <div class="row">
+    <div class="d-flex flex-column gap-4">
         @foreach (var issue in Model.Issues)
         {
-            <div class="col-12 mb-3">
-                <div class="card">
-                    <div class="card-body">
-                        <div class="row">
-                            <div class="col-md-8">
-                                <h5 class="card-title">@issue.Title</h5>
-                                <p class="card-text text-muted">@issue.Description</p>
-                                <div class="d-flex flex-wrap gap-2 mb-2">
-                                    <span class="badge" style="background-color: @issue.Category.Color">
-                                        @issue.Category.Name
-                                    </span>
-                                    <span class="badge bg-@(issue.Status switch
-                                    {
-                                        IssueStatus.Pending => "warning",
-                                        IssueStatus.InProgress => "info",
-                                        IssueStatus.Resolved => "success",
-                                        IssueStatus.Rejected => "danger",
-                                        _ => "secondary"
-                                    })">
-                                        @issue.Status
-                                    </span>
-                                    <span class="badge bg-@(issue.Priority switch
-                                    {
-                                        Priority.Low => "secondary",
-                                        Priority.Medium => "warning",
-                                        Priority.High => "danger",
-                                        Priority.Urgent => "danger",
-                                        _ => "secondary"
-                                    })">
-                                        @issue.Priority
-                                    </span>
-                                </div>
-                                <div class="text-muted small">
-                                    <i class="fas fa-map-marker-alt me-1"></i>@issue.Location
-                                    <span class="mx-2">•</span>
-                                    <i class="fas fa-calendar me-1"></i>@issue.CreatedAt.ToString("MMM dd, yyyy")
+            <div class="issue-card">
+                <div class="issue-card-content">
+                    <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                        <div class="flex-grow-1">
+                            <h3 class="h4 text-white mb-2">@issue.Title</h3>
+                            <p class="text-muted mb-0">@issue.Description</p>
+                        </div>
+                        <div class="issue-actions">
+                            <a asp-controller="Issues" asp-action="Details" asp-route-id="@issue.Id" class="btn btn-outline-primary btn-sm rounded-pill px-4">
+                                <i class="fas fa-eye me-1"></i>View Details
+                            </a>
+                        </div>
+                    </div>
+                    <div class="issue-meta">
+                        <span class="chip chip-category" style="background: linear-gradient(135deg, @issue.Category.Color, rgba(255,255,255,0.15));">
+                            <i class="fas fa-layer-group"></i>@issue.Category.Name
+                        </span>
+                        <span class="chip chip-status @(issue.Status switch
+                        {
+                            IssueStatus.Pending => "pending",
+                            IssueStatus.InProgress => "in-progress",
+                            IssueStatus.Resolved => "resolved",
+                            IssueStatus.Rejected => "rejected",
+                            _ => string.Empty
+                        })">
+                            <i class="fas fa-signal"></i>@issue.Status
+                        </span>
+                        <span class="chip chip-priority @(issue.Priority switch
+                        {
+                            Priority.High => "high",
+                            Priority.Urgent => "urgent",
+                            _ => string.Empty
+                        })">
+                            <i class="fas fa-bolt"></i>@issue.Priority
+                        </span>
+                    </div>
+                    <div class="issue-footer">
+                        <div class="d-flex flex-wrap align-items-center gap-3">
+                            <span><i class="fas fa-map-marker-alt me-2"></i>@issue.Location</span>
+                            <span><i class="fas fa-calendar me-2"></i>@issue.CreatedAt.ToString("MMM dd, yyyy")</span>
                             @if (issue.Assignee != null)
-                                    {
-                                        <span class="mx-2">•</span>
-                                        <i class="fas fa-user me-1"></i>
-                                        <span>Assigned to: @issue.Assignee.Name</span>
-                                    }
-
-                                </div>
-                            </div>
-                            <div class="col-md-4 text-end">
-                                <a asp-controller="Issues" asp-action="Details" asp-route-id="@issue.Id" class="btn btn-outline-primary btn-sm">
-                                    <i class="fas fa-eye me-1"></i>View Details
-                                </a>
-                            </div>
+                            {
+                                <span><i class="fas fa-user me-2"></i>Assigned to @issue.Assignee.Name</span>
+                            }
                         </div>
                     </div>
                 </div>
@@ -114,11 +125,11 @@
 }
 else
 {
-    <div class="text-center py-5">
-        <i class="fas fa-inbox fa-3x text-muted mb-3"></i>
-        <h5>No issues found</h5>
-        <p class="text-muted">@(Model.CurrentFilter.HasValue ? $"No {Model.CurrentFilter} issues found." : "You haven't reported any issues yet.")</p>
-        <a asp-controller="Issues" asp-action="Create" class="btn btn-primary">
+    <div class="empty-state text-center">
+        <i class="fas fa-inbox fa-3x text-white-50 mb-3"></i>
+        <h5 class="text-white mb-2">No issues found</h5>
+        <p class="text-white-50 mb-4">@(Model.CurrentFilter.HasValue ? $"No {Model.CurrentFilter} issues found." : "You haven't reported any issues yet.")</p>
+        <a asp-controller="Issues" asp-action="Create" class="btn btn-primary btn-lg px-4">
             <i class="fas fa-plus me-2"></i>Report Your First Issue
         </a>
     </div>

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Shared/_Layout.cshtml
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/Views/Shared/_Layout.cshtml
@@ -9,7 +9,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="~/css/site.css" rel="stylesheet" />
 </head>
+
 <body class="bg-app text-body">
+    @{
+        var useFullWidth = ViewData["UseFullWidth"] as bool? ?? false;
+        var mainPaddingClass = ViewData["MainPaddingClass"] as string ?? "py-5";
+    }
     <div class="background-gradient"></div>
     <div class="background-pattern"></div>
     <header class="position-relative">
@@ -56,10 +61,17 @@
         </nav>
     </header>
     <div class="main-wrapper position-relative">
-        <main role="main" class="py-5">
-            <div class="container-xl">
+        <main role="main" class="@mainPaddingClass">
+            @if (useFullWidth)
+            {
                 @RenderBody()
-            </div>
+            }
+            else
+            {
+                <div class="container-xl">
+                    @RenderBody()
+                </div>
+            }
         </main>
     </div>
     <footer class="footer-modern text-white py-4">

--- a/AspDotNetCorePortal/CitizenEngagementPortal.Web/wwwroot/css/site.css
+++ b/AspDotNetCorePortal/CitizenEngagementPortal.Web/wwwroot/css/site.css
@@ -505,6 +505,18 @@ body {
     color: #e2e8f0;
 }
 
+.comment-author {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(14, 165, 233, 0.75));
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
 .pagination .page-link {
     background: rgba(15, 23, 42, 0.78);
     border: 1px solid rgba(148, 163, 184, 0.2);
@@ -515,6 +527,369 @@ body {
 .pagination .page-item.active .page-link {
     background: rgba(99, 102, 241, 0.8);
     border-color: rgba(99, 102, 241, 0.9);
+}
+
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+}
+
+.page-title {
+    margin: 0;
+    color: #fff;
+    font-weight: 700;
+    font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.page-subtitle {
+    color: rgba(226, 232, 240, 0.65);
+    max-width: 38rem;
+    margin-top: 0.5rem;
+}
+
+.page-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.tab-modern.nav-tabs {
+    border-bottom: 0;
+    display: inline-flex;
+    gap: 0.75rem;
+    background: rgba(15, 23, 42, 0.6);
+    padding: 0.5rem;
+    border-radius: 999px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.tab-modern .nav-link {
+    border: 0;
+    border-radius: 999px;
+    color: rgba(226, 232, 240, 0.65);
+    font-weight: 500;
+    padding: 0.55rem 1.4rem;
+    transition: all 0.2s ease;
+}
+
+.tab-modern .nav-link:hover,
+.tab-modern .nav-link:focus {
+    color: #fff;
+    background: rgba(99, 102, 241, 0.35);
+}
+
+.tab-modern .nav-link.active {
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.85), rgba(14, 165, 233, 0.8));
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(99, 102, 241, 0.35);
+}
+
+.issue-card {
+    position: relative;
+    background: rgba(15, 23, 42, 0.88);
+    border-radius: 1.75rem;
+    padding: 2rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    overflow: hidden;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.issue-card::before {
+    content: "";
+    position: absolute;
+    inset: -30% 60% 40% -30%;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(14, 165, 233, 0.2));
+    transform: rotate(8deg);
+    filter: blur(35px);
+    opacity: 0.75;
+}
+
+.issue-card-content {
+    position: relative;
+    z-index: 1;
+}
+
+.issue-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 1rem 0 1.25rem;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.95rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.chip i {
+    font-size: 0.85rem;
+}
+
+.chip-category {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.chip-status {
+    color: #fff;
+}
+
+.chip-status.pending { background: linear-gradient(135deg, #f59e0b, #f97316); }
+.chip-status.in-progress { background: linear-gradient(135deg, #0ea5e9, #6366f1); }
+.chip-status.resolved { background: linear-gradient(135deg, #10b981, #22d3ee); }
+.chip-status.rejected { background: linear-gradient(135deg, #ef4444, #f97316); }
+
+.chip-priority {
+    background: rgba(148, 163, 184, 0.18);
+}
+
+.chip-priority.high,
+.chip-priority.urgent {
+    background: rgba(248, 113, 113, 0.25);
+    color: #fecaca;
+}
+
+.issue-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    color: rgba(226, 232, 240, 0.65);
+    font-size: 0.9rem;
+}
+
+.issue-footer i {
+    color: rgba(226, 232, 240, 0.6);
+}
+
+.issue-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.issue-actions .btn-outline-primary {
+    border-color: rgba(99, 102, 241, 0.65);
+    color: #c7d2fe;
+}
+
+.issue-actions .btn-outline-primary:hover {
+    background: rgba(99, 102, 241, 0.65);
+    color: #fff;
+}
+
+.empty-state {
+    background: rgba(15, 23, 42, 0.78);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    padding: 3rem;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.3);
+}
+
+.metric-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    margin-bottom: 2.5rem;
+}
+
+.metric-tile {
+    position: relative;
+    border-radius: 1.5rem;
+    padding: 1.75rem;
+    overflow: hidden;
+    color: #fff;
+    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.35);
+}
+
+.metric-tile::after {
+    content: "";
+    position: absolute;
+    inset: 25% -20% -30% 40%;
+    background: rgba(255, 255, 255, 0.12);
+    filter: blur(35px);
+    transform: rotate(-12deg);
+}
+
+.metric-tile .icon {
+    font-size: 2rem;
+    opacity: 0.65;
+}
+
+.metric-tile .value {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0.75rem 0 0.25rem;
+}
+
+.metric-tile .label {
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    opacity: 0.8;
+}
+
+.metric-tile.gradient-blue { background: linear-gradient(135deg, #6366f1, #0ea5e9); }
+.metric-tile.gradient-amber { background: linear-gradient(135deg, #f97316, #facc15); }
+.metric-tile.gradient-cyan { background: linear-gradient(135deg, #0ea5e9, #8b5cf6); }
+.metric-tile.gradient-emerald { background: linear-gradient(135deg, #10b981, #22d3ee); }
+.metric-tile.gradient-slate { background: linear-gradient(135deg, #334155, #6366f1); }
+.metric-tile.gradient-rose { background: linear-gradient(135deg, #f43f5e, #f97316); }
+
+.table-modern {
+    border-radius: 1.5rem;
+    overflow: hidden;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table-modern thead {
+    background: rgba(99, 102, 241, 0.18);
+    color: #fff;
+}
+
+.table-modern tbody tr {
+    transition: background 0.2s ease;
+}
+
+.table-modern tbody tr:hover {
+    background: rgba(99, 102, 241, 0.12);
+}
+
+.badge-soft {
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    font-weight: 600;
+    background: rgba(148, 163, 184, 0.18);
+    color: #e2e8f0;
+}
+
+.badge-soft.status-pending { background: rgba(250, 204, 21, 0.2); color: #fef08a; }
+.badge-soft.status-progress { background: rgba(59, 130, 246, 0.22); color: #bfdbfe; }
+.badge-soft.status-resolved { background: rgba(34, 197, 94, 0.22); color: #bbf7d0; }
+.badge-soft.status-rejected { background: rgba(248, 113, 113, 0.22); color: #fecaca; }
+
+.list-modern {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.list-modern-item {
+    background: rgba(15, 23, 42, 0.75);
+    border-radius: 1.25rem;
+    padding: 1.25rem 1.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.list-modern-item .badge-soft {
+    margin-top: 0.5rem;
+}
+
+.form-card {
+    background: rgba(15, 23, 42, 0.82);
+    border-radius: 1.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.38);
+}
+
+.form-card .card-header {
+    padding: 2.25rem 2.25rem 1.5rem;
+}
+
+.form-card .card-body {
+    padding: 2.25rem;
+}
+
+.form-card .card-footer {
+    padding: 1.75rem 2.25rem;
+}
+
+.form-section-title {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(226, 232, 240, 0.55);
+    margin-bottom: 1rem;
+}
+
+.auth-wrapper {
+    min-height: calc(100vh - 240px);
+    display: grid;
+    place-items: center;
+    padding: 3rem 0;
+}
+
+.auth-card {
+    background: rgba(15, 23, 42, 0.82);
+    border-radius: 1.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+    overflow: hidden;
+}
+
+.auth-card .card-header,
+.auth-card .card-body,
+.auth-card .card-footer {
+    background: transparent;
+    border: 0;
+}
+
+.auth-card .card-header {
+    padding: 2.5rem 2.5rem 1.75rem;
+}
+
+.auth-card .card-body {
+    padding: 0 2.5rem 2.5rem;
+}
+
+.auth-card .card-footer {
+    padding: 1.75rem 2.5rem 2.5rem;
+    background: rgba(148, 163, 184, 0.08);
+}
+
+.auth-card a {
+    color: #a5b4fc;
+}
+
+.card-section-divider {
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, transparent, rgba(148, 163, 184, 0.4), transparent);
+    margin: 2rem 0;
+}
+
+.text-white-75 {
+    color: rgba(226, 232, 240, 0.75) !important;
+}
+
+.section-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.section-heading .title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.section-heading .subtitle {
+    color: rgba(226, 232, 240, 0.55);
+    font-size: 0.9rem;
 }
 
 @media (max-width: 991.98px) {


### PR DESCRIPTION
## Summary
- allow the shared layout to switch between default container padding and full-width rendering via view data flags
- update the home landing page to opt into the full-width experience and align its hero actions with the modern button styles

## Testing
- `dotnet build AspDotNetCorePortal/CitizenEngagementPortal.Web/CitizenEngagementPortal.Web.csproj` *(fails: `dotnet` CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e591a2520c8333a702b0064f0db735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive UI refresh across Login, Register, Dashboard, Admin, and Issues pages with modern layouts, metric tiles, and responsive sections.
  * Enhanced Issues experience: redesigned list and details, chip-style status/priority, media gallery, improved actions (assign/resolve), and clearer timelines.
  * Improved Admin analytics with data-driven charts and top categories; dashboards now include empty-state handling.
  * Issue creation now supports latitude/longitude inputs and clearer file attachments.
  * Layout supports full-width pages and configurable padding.

* **Style**
  * New design system: gradient tiles, modern tables/lists, tabs, chips/badges, auth cards, and refined CTAs for a consistent, polished look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->